### PR TITLE
Adding Solid World Coordinator role

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ Editors have [_Admin Permissions_](https://help.github.com/en/articles/repositor
 
 # Administration
 
-Administrators are granted privileged access to control the tools, systems, and services used for advancing the Solid. This includes the [Solid GitHub](https://github.com/solid) organization, [Solid Gitter](https://gitter.im/solid/home) channels, the [Solid Forum](https://forum.solidproject.org), and the [Solid Website](https://www.solidproject.org).
+Administrators are granted privileged access to control the tools, systems, and services used for advancing Solid. This includes the [Solid GitHub](https://github.com/solid) organization, [Solid Gitter](https://gitter.im/solid/home) channels, the [Solid Forum](https://forum.solidproject.org), and the [Solid Website](https://www.solidproject.org).
 
 Administrators belong to the [Administrators Team](https://github.com/orgs/solid/teams/administrators) in the [Solid GitHub Organization](https://github.com/solid) and have [_Admin Permissions_](https://help.github.com/en/articles/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization) on all repositories therein. Administrators have [_Owner Permissions_](https://help.github.com/en/articles/permission-levels-for-an-organization#permission-levels-for-an-organization) for the [Solid GitHub Organization](https://github.com/solid).
+
+The Solid World Coordination Administrator is granted privileged access to only those tools, systems, and services required to coordinate and promote the monthly Solid World webinar, including Vimeo, Twitter, Eventbrite and Typeform.
 
 ### Becoming an Administrator
 


### PR DESCRIPTION
At the last Solid Team meeting, we agreed that we need to formally acknowledge the work being done to coordinate Solid World, but that such work should not require a full Solid Administrator position. This PR describes a new roles with more limited admin prvileges.